### PR TITLE
[COLRv1] Add COLR API to iterate color stops (#59703)

### DIFF
--- a/src/sfnt/ttcolr.c
+++ b/src/sfnt/ttcolr.c
@@ -663,6 +663,39 @@
     return 1;
   }
 
+  FT_LOCAL_DEF ( FT_Bool )
+  tt_face_get_colorline_stops ( TT_Face               face,
+                                FT_ColorStop *        color_stop,
+                                FT_ColorStopIterator *iterator )
+  {
+    Colr* colr = (Colr*)face->colr;
+    FT_Byte *p;
+
+
+    if ( iterator->current_color_stop >= iterator->num_color_stops )
+      return 0;
+
+    if ( iterator->p +
+             ( ( iterator->num_color_stops - iterator->current_color_stop ) *
+               COLOR_STOP_SIZE ) >
+         (FT_Byte *)( colr->table + colr->table_size ) )
+      return 0;
+
+    /* Iterator points at first ColorStop of ColorLine */
+    p = iterator->p;
+
+    color_stop->stop_offset         = FT_NEXT_USHORT ( p );
+    FT_NEXT_ULONG ( p ); /* skip varIdx */
+    color_stop->color.palette_index = FT_NEXT_USHORT ( p );
+    color_stop->color.alpha         = FT_NEXT_USHORT ( p );
+    FT_NEXT_ULONG ( p ); /* skip varIdx */
+
+    iterator->p = p;
+    iterator->current_color_stop++;
+
+    return 1;
+  }
+
   FT_LOCAL_DEF( FT_Bool )
   tt_face_get_paint( TT_Face        face,
                      FT_OpaquePaint opaque_paint,

--- a/src/sfnt/ttcolr.h
+++ b/src/sfnt/ttcolr.h
@@ -48,6 +48,11 @@ FT_BEGIN_HEADER
                                 FT_OpaquePaint*   paint );
 
   FT_LOCAL( FT_Bool )
+  tt_face_get_colorline_stops( TT_Face               face,
+                               FT_ColorStop*         color_stop,
+                               FT_ColorStopIterator* iterator );
+
+  FT_LOCAL( FT_Bool )
   tt_face_get_paint( TT_Face        face,
                      FT_OpaquePaint opaque_paint,
                      FT_COLR_Paint*      paint );


### PR DESCRIPTION
* src/sfnt/ttcolr.h (tt_face_get_colorline_stops): Add colr table API to
  retrieve individual color stops using an FT_ColorStopIterator
  retrieved as a FT_ColorLine member of an FT_COLR_Paint object via
  tt_face_get_paint.
* src/sfnt/ttcolr.c (tt_face_get_colorline_stops): Return the current
  FT_ColorStop from FT_ColorStopIterator and increment the iterator.