### PR TITLE
[COLRv1] Register new COLR API in sfnt driver (#59703)

### DIFF
--- a/include/freetype/internal/sfnt.h
+++ b/include/freetype/internal/sfnt.h
@@ -523,6 +523,23 @@ FT_BEGIN_HEADER
                              FT_UInt           *acolor_index,
                              FT_LayerIterator*  iterator );
 
+  typedef FT_Bool ( *TT_Get_Color_Glyph_Paint_Func )( TT_Face face,
+                                                      FT_UInt base_glyph,
+                                                      FT_OpaquePaint* paint );
+
+  typedef FT_Bool ( *TT_Get_Paint_Layers_Func )( TT_Face           face,
+                                                 FT_LayerIterator* iterator,
+                                                 FT_OpaquePaint*   paint );
+
+  typedef FT_Bool
+  ( *TT_Get_Colorline_Stops_Func )( TT_Face face,
+                                    FT_ColorStop *color_stop,
+                                    FT_ColorStopIterator *iterator );
+
+  typedef FT_Bool
+  ( *TT_Get_Paint_Func )( TT_Face        face,
+                          FT_OpaquePaint opaque_paint,
+                          FT_COLR_Paint* paint );
 
   /**************************************************************************
    *
@@ -709,73 +726,77 @@ FT_BEGIN_HEADER
    */
   typedef struct  SFNT_Interface_
   {
-    TT_Loader_GotoTableFunc      goto_table;
+    TT_Loader_GotoTableFunc        goto_table;
 
-    TT_Init_Face_Func            init_face;
-    TT_Load_Face_Func            load_face;
-    TT_Done_Face_Func            done_face;
-    FT_Module_Requester          get_interface;
+    TT_Init_Face_Func              init_face;
+    TT_Load_Face_Func              load_face;
+    TT_Done_Face_Func              done_face;
+    FT_Module_Requester            get_interface;
 
-    TT_Load_Any_Func             load_any;
+    TT_Load_Any_Func               load_any;
 
     /* these functions are called by `load_face' but they can also  */
     /* be called from external modules, if there is a need to do so */
-    TT_Load_Table_Func           load_head;
-    TT_Load_Metrics_Func         load_hhea;
-    TT_Load_Table_Func           load_cmap;
-    TT_Load_Table_Func           load_maxp;
-    TT_Load_Table_Func           load_os2;
-    TT_Load_Table_Func           load_post;
+    TT_Load_Table_Func             load_head;
+    TT_Load_Metrics_Func           load_hhea;
+    TT_Load_Table_Func             load_cmap;
+    TT_Load_Table_Func             load_maxp;
+    TT_Load_Table_Func             load_os2;
+    TT_Load_Table_Func             load_post;
 
-    TT_Load_Table_Func           load_name;
-    TT_Free_Table_Func           free_name;
+    TT_Load_Table_Func             load_name;
+    TT_Free_Table_Func             free_name;
 
     /* this field was called `load_kerning' up to version 2.1.10 */
-    TT_Load_Table_Func           load_kern;
+    TT_Load_Table_Func             load_kern;
 
-    TT_Load_Table_Func           load_gasp;
-    TT_Load_Table_Func           load_pclt;
+    TT_Load_Table_Func             load_gasp;
+    TT_Load_Table_Func             load_pclt;
 
     /* see `ttload.h'; this field was called `load_bitmap_header' up to */
     /* version 2.1.10                                                   */
-    TT_Load_Table_Func           load_bhed;
+    TT_Load_Table_Func             load_bhed;
 
-    TT_Load_SBit_Image_Func      load_sbit_image;
+    TT_Load_SBit_Image_Func        load_sbit_image;
 
     /* see `ttpost.h' */
-    TT_Get_PS_Name_Func          get_psname;
-    TT_Free_Table_Func           free_psnames;
+    TT_Get_PS_Name_Func            get_psname;
+    TT_Free_Table_Func             free_psnames;
 
     /* starting here, the structure differs from version 2.1.7 */
 
     /* this field was introduced in version 2.1.8, named `get_psname' */
-    TT_Face_GetKerningFunc       get_kerning;
+    TT_Face_GetKerningFunc         get_kerning;
 
     /* new elements introduced after version 2.1.10 */
 
     /* load the font directory, i.e., the offset table and */
     /* the table directory                                 */
-    TT_Load_Table_Func           load_font_dir;
-    TT_Load_Metrics_Func         load_hmtx;
+    TT_Load_Table_Func             load_font_dir;
+    TT_Load_Metrics_Func           load_hmtx;
 
-    TT_Load_Table_Func           load_eblc;
-    TT_Free_Table_Func           free_eblc;
+    TT_Load_Table_Func             load_eblc;
+    TT_Free_Table_Func             free_eblc;
 
-    TT_Set_SBit_Strike_Func      set_sbit_strike;
-    TT_Load_Strike_Metrics_Func  load_strike_metrics;
+    TT_Set_SBit_Strike_Func        set_sbit_strike;
+    TT_Load_Strike_Metrics_Func    load_strike_metrics;
 
-    TT_Load_Table_Func           load_cpal;
-    TT_Load_Table_Func           load_colr;
-    TT_Free_Table_Func           free_cpal;
-    TT_Free_Table_Func           free_colr;
-    TT_Set_Palette_Func          set_palette;
-    TT_Get_Colr_Layer_Func       get_colr_layer;
-    TT_Blend_Colr_Func           colr_blend;
+    TT_Load_Table_Func             load_cpal;
+    TT_Load_Table_Func             load_colr;
+    TT_Free_Table_Func             free_cpal;
+    TT_Free_Table_Func             free_colr;
+    TT_Set_Palette_Func            set_palette;
+    TT_Get_Colr_Layer_Func         get_colr_layer;
+    TT_Get_Color_Glyph_Paint_Func  get_colr_glyph_paint;
+    TT_Get_Paint_Layers_Func       get_paint_layers;
+    TT_Get_Colorline_Stops_Func    get_colorline_stops;
+    TT_Get_Paint_Func              get_paint;
+    TT_Blend_Colr_Func             colr_blend;
 
-    TT_Get_Metrics_Func          get_metrics;
+    TT_Get_Metrics_Func            get_metrics;
 
-    TT_Get_Name_Func             get_name;
-    TT_Get_Name_ID_Func          get_name_id;
+    TT_Get_Name_Func               get_name;
+    TT_Get_Name_ID_Func            get_name_id;
 
   } SFNT_Interface;
 
@@ -820,6 +841,10 @@ FT_BEGIN_HEADER
           free_colr_,                    \
           set_palette_,                  \
           get_colr_layer_,               \
+          get_colr_glyph_paint_,         \
+          get_paint_layers_,             \
+          get_colorline_stops_,          \
+          get_paint_,                    \
           colr_blend_,                   \
           get_metrics_,                  \
           get_name_,                     \
@@ -860,6 +885,10 @@ FT_BEGIN_HEADER
     free_colr_,                          \
     set_palette_,                        \
     get_colr_layer_,                     \
+    get_colr_glyph_paint_,               \
+    get_paint_layers_,                   \
+    get_colorline_stops_,                \
+    get_paint_,                          \
     colr_blend_,                         \
     get_metrics_,                        \
     get_name_,                           \

--- a/src/sfnt/sfdriver.c
+++ b/src/sfnt/sfdriver.c
@@ -1213,6 +1213,8 @@
 #define PUT_COLOR_LAYERS( a )  NULL
 #endif
 
+#define PUT_COLOR_LAYERS_V1( a ) PUT_COLOR_LAYERS( a )
+
 #ifdef TT_CONFIG_OPTION_POSTSCRIPT_NAMES
 #define PUT_PS_NAMES( a )  a
 #else
@@ -1271,9 +1273,9 @@
                             /* TT_Free_Table_Func      free_eblc       */
 
     PUT_EMBEDDED_BITMAPS( tt_face_set_sbit_strike     ),
-                   /* TT_Set_SBit_Strike_Func      set_sbit_strike     */
+                  /* TT_Set_SBit_Strike_Func      set_sbit_strike      */
     PUT_EMBEDDED_BITMAPS( tt_face_load_strike_metrics ),
-                   /* TT_Load_Strike_Metrics_Func  load_strike_metrics */
+                  /* TT_Load_Strike_Metrics_Func  load_strike_metrics  */
 
     PUT_COLOR_LAYERS( tt_face_load_cpal ),
                             /* TT_Load_Table_Func      load_cpal       */
@@ -1287,6 +1289,14 @@
                             /* TT_Set_Palette_Func     set_palette     */
     PUT_COLOR_LAYERS( tt_face_get_colr_layer ),
                             /* TT_Get_Colr_Layer_Func  get_colr_layer  */
+    PUT_COLOR_LAYERS_V1( tt_face_get_colr_glyph_paint ),
+                  /* TT_Get_Colr_Glyph_Paint_Func get_colr_glyph_paint */
+    PUT_COLOR_LAYERS_V1( tt_face_get_paint_layers ),
+                  /* TT_Get_Paint_Layers_Func     get_paint_layers     */
+    PUT_COLOR_LAYERS_V1( tt_face_get_colorline_stops ),
+                  /* TT_Get_Paint                 get_paint            */
+    PUT_COLOR_LAYERS_V1( tt_face_get_paint ),
+                  /* TT_Get_Colorline_Stops_Func  get_colorline_stops  */
     PUT_COLOR_LAYERS( tt_face_colr_blend_layer ),
                             /* TT_Blend_Colr_Func      colr_blend      */
 


### PR DESCRIPTION
* include/freetype/internal/sfnt.h (TT_Get_Color_Glyph_Paint_Func,
  TT_Get_Paint_Layers_Func, TT_Get_Colorline_Stops_Func,
  TT_Get_Paint_Func, SFNT_Interface): Add function pointer types for new
  API mapping to new functions in ttcolr.h, add those function pointers
  as member functions to the sfnt interface.
* src/sfnt/sfdriver.c (FT_DEFINE_SFNT_INTERFACE): For the newly defined
  SFNT interface functions, point to implementations in ttcolr.